### PR TITLE
Adding message support for System.Diagnostics.Debug.Assert calls.

### DIFF
--- a/AssemblyToProcess/AssemblyToProcess.csproj
+++ b/AssemblyToProcess/AssemblyToProcess.csproj
@@ -49,6 +49,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DebugTests.cs" />
     <Compile Include="NunitTests.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/AssemblyToProcess/DebugTests.cs
+++ b/AssemblyToProcess/DebugTests.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace AssemblyToProcess
+{
+  public class ErrorThrowingTraceListener : TraceListener
+  {
+    public override void Write(string message)
+    {
+      throw new NotImplementedException();
+    }
+
+    public override void WriteLine(string message)
+    {
+      throw new NotImplementedException();
+    }
+
+    public override void Fail(string message)
+    {
+      throw new Exception(message);
+    }
+  }
+
+  public class DebugTests
+  {
+    static DebugTests()
+    {
+      Trace.Listeners.Remove("Default");
+      Trace.Listeners.Add(new ErrorThrowingTraceListener());
+    }
+
+    public void False_should_have_message()
+    {
+      var actual = false;
+
+      Debug.Assert(actual);
+    }
+
+    public void False_should_have_original_message()
+    {
+      var actual = false;
+
+      Debug.Assert(actual, "original");
+    }
+  }
+}

--- a/Fody/Fody.csproj
+++ b/Fody/Fody.csproj
@@ -71,6 +71,7 @@
     <Compile Include="InstructionToInsert.cs" />
     <Compile Include="ModuleWeaver.cs" />
     <Compile Include="..\CommonAssemblyInfo.cs" />
+    <Compile Include="Processors\DebugProcessor.cs" />
     <Compile Include="Processors\XunitProcessor.cs" />
     <Compile Include="Processors\MstestProcessor.cs" />
     <Compile Include="Processors\IProcessor.cs" />

--- a/Fody/Processors/DebugProcessor.cs
+++ b/Fody/Processors/DebugProcessor.cs
@@ -1,0 +1,26 @@
+﻿using Mono.Cecil;
+
+namespace AssertMessage.Fody.Processors
+{
+  public class DebugProcessor : ProcessorBase
+  {
+    public override bool IsValidForModule(ModuleDefinition module)
+    {
+      return IsReferenced(module, "System");
+    }
+
+    protected override bool IsThisFramework(MethodReference methodReference)
+    {
+      return IsTypeFrom(methodReference, "System.Diagnostics.Debug");
+    }
+
+    protected override bool IsAssertMethod(MethodReference methodReference)
+    {
+      var resolved = methodReference.Resolve();
+      var name = resolved.DeclaringType.Name;
+      var methodName = resolved.Name;
+
+      return (name.Equals("Debug") && methodName.Equals("Assert"));
+    }
+  }
+}

--- a/Tests/DebugTests.cs
+++ b/Tests/DebugTests.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace Tests
+{
+  [TestFixture]
+  public class DebugTests : IntegrationTestsBase<Exception>
+  {
+    [Test]
+    public void False_should_have_message()
+    {
+      CheckIfMessageIsValid("Debug.Assert(actual);");
+    }
+
+    [Test]
+    public void False_should_have_original_message()
+    {
+      CheckIfMessageIsValid("original");
+    }
+  }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -72,6 +72,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyLoader.cs" />
+    <Compile Include="DebugTests.cs" />
     <Compile Include="XunitTests.cs" />
     <Compile Include="MstestTests.cs" />
     <Compile Include="IntegrationTestsBase.cs" />


### PR DESCRIPTION
I use the Debug.Assert statement frequently in my code, but I almost never pass in an actual message.  This sometimes makes it difficult to determine which Debug.Assert is being triggered.  I updated the AssertMessage aspect to handle automatically entering in a message for use with Debug.Assert.